### PR TITLE
Scan messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# local ignores
+secrets.json
+tryout.js
+
 # Logs
 logs
 *.log
@@ -61,6 +65,7 @@ typings/
 
 # Optional REPL history
 .node_repl_history
+
 
 # Output of 'npm pack'
 *.tgz

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # autotag-action
 
-A lightning fast autotagger for `semver` tagging.
+A lightning fast autotagger for `semver`-tagging. This action scans the commit messages for fixed issues and semver changes. If a commit message fixes an issue, 
+`autotag-action` will check wether the issue was labled as an *enhancement* that triggers a `minor` release, or a bug fix that will be treated as a `patch`. 
 
 This action has been inspired by [anothrNick/github-tag-action](/anothrNick/github-tag-action), but is written completely in javascript and runs directly within the runner.
 
-`autotag-action` uses [`Octokit`](https://octokit.github.io/rest.js/v17) for tagging and does not depend on checking out the repository. 
+`autotag-action` uses [`Octokit`](https://octokit.github.io/rest.js) for tagging and does not depend on checking out the repository. 
 
 ## Inputs
 
@@ -34,13 +35,21 @@ This input is useful if subsequent steps manipulate a different branch, which sh
 
 ### `release-branch`
 
-**Optional** a comma-separated list of branch names or regular expressions. (Default: `master`)
+**Optional** A comma-separated list of branch names or regular expressions. (Default: `master`)
+
+### `tag`
+
+**Optional** Custom tag to be added to the current SHA. Will not perform any version bumping, but adds the provided tag.
+
+### `issue-labels`
+
+**Optional** A comma-separated list of issue labels that changes the bump level from `patch` to `minor` (Default: `enhancement`).
 
 ## Outputs
 
 ### `tag`
 
-The previous latest tag before this action ran.
+The previous latest tag before this action ran. This output is unavailable, when the `tag` input is used.
 
 ### `new-tag`
 
@@ -216,3 +225,9 @@ jobs:
           bump: ${{ steps.contributor.outputs.release || steps.bot.outputs.release }}
           with-v: true
 ```
+
+## More advanced usages
+
+The `tag` input allows to use a custom tag for tagging. This is useful when generating or applying tags. 
+
+The `issue-labels` input allows to define issues labels that should be considered as minor versions (API extensions). The default is the `enhancement` label. All other labels are treated as patches that do not change the API.

--- a/dist/index.js
+++ b/dist/index.js
@@ -2510,9 +2510,11 @@ async function action() {
         }
 
         // check if commits and issues point to a diffent release
+        console.log("================> commits since main");
         const msgLevel = await checkMessages(octokit, latestMainTag.commit.sha, issLabs);
-        console.log("================> commits in branch");
+        console.log("================> commits since alpha");
         const msgLevelB = await checkMessages(octokit, latestTag.commit.sha, issLabs);
+        console.log("================> commits in branch");
         const msgLevelC = await checkMessages(octokit, branchInfo.object.sha, issLabs);
 
         console.log(`commit messages suggest ${msgLevel} upgrade`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2325,8 +2325,10 @@ async function loadBranch(octokit, branch) {
     return result.data.shift();
 }
 
-async function checkMessages(octokit, latestTag, issueTags) {
-    const sha = latestTag.commit.sha;
+async function checkMessages(octokit, sha, issueTags) {
+    // const sha = latestTag.commit.sha;
+
+    console.log(`load commits since ${sha}`);
 
     let releaseBump = "none";
 
@@ -2508,11 +2510,14 @@ async function action() {
         }
 
         // check if commits and issues point to a diffent release
-        const msgLevel = await checkMessages(octokit, latestMainTag, issLabs);
-        const msgLevelB = await checkMessages(octokit, latestTag, issLabs);
+        const msgLevel = await checkMessages(octokit, latestMainTag.commit.sha, issLabs);
+        console.log("================> commits in branch");
+        const msgLevelB = await checkMessages(octokit, latestTag.commit.sha, issLabs);
+        const msgLevelC = await checkMessages(octokit, branchInfo.object.sha, issLabs);
 
         console.log(`commit messages suggest ${msgLevel} upgrade`);
         console.log(`commit messages since minor suggest ${msgLevelB} upgrade`);
+        console.log(`commit messages for branch suggest ${msgLevelC} upgrade`);
         
         for (const branch of releaseBranch.split(",").map(b => b.trim())) {
             const testBranchName = new RegExp(branch);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2353,7 +2353,7 @@ async function checkMessages(octokit, latestTag, issueTags) {
         const message = commit.commit.message;
 
         // console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
-        console.log(`message is : "${message}" on ${commit.commit.committer.date}`);
+        console.log(`message is : "${message}" on ${commit.commit.committer.date} (${commit.sha})`);
 
         if (wip.test(message)) {
             console.log("    found wip message, skip");

--- a/dist/index.js
+++ b/dist/index.js
@@ -2325,7 +2325,7 @@ async function loadBranch(octokit, branch) {
     return result.data.shift();
 }
 
-async function checkMessages(octokit, sha, issueTags) {
+async function checkMessages(octokit, sha, tagSha, issueTags) {
     // const sha = latestTag.commit.sha;
 
     console.log(`load commits since ${sha}`);
@@ -2354,6 +2354,9 @@ async function checkMessages(octokit, sha, issueTags) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
+        if (commit.sha === tagSha) {
+            break;
+        }
         // console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
         console.log(`message is : "${message}" on ${commit.commit.committer.date} (${commit.sha})`);
 
@@ -2510,16 +2513,16 @@ async function action() {
         }
 
         // check if commits and issues point to a diffent release
-        console.log("================> commits since main");
-        const msgLevel = await checkMessages(octokit, latestMainTag.commit.sha, issLabs);
-        console.log("================> commits since alpha");
-        const msgLevelB = await checkMessages(octokit, latestTag.commit.sha, issLabs);
+        // console.log("================> commits since main");
+        // const msgLevel = await checkMessages(octokit, latestMainTag.commit.sha, issLabs);
+        // console.log("================> commits since alpha");
+        // const msgLevelB = await checkMessages(octokit, latestTag.commit.sha, issLabs);
         console.log("================> commits in branch");
-        const msgLevelC = await checkMessages(octokit, branchInfo.object.sha, issLabs);
+        const msgLevel = await checkMessages(octokit, branchInfo.object.sha, latestMainTag.commit.sha,  issLabs);
 
         console.log(`commit messages suggest ${msgLevel} upgrade`);
-        console.log(`commit messages since minor suggest ${msgLevelB} upgrade`);
-        console.log(`commit messages for branch suggest ${msgLevelC} upgrade`);
+        // console.log(`commit messages since minor suggest ${msgLevelB} upgrade`);
+        // console.log(`commit messages for branch suggest ${msgLevelC} upgrade`);
         
         for (const branch of releaseBranch.split(",").map(b => b.trim())) {
             const testBranchName = new RegExp(branch);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2470,7 +2470,7 @@ async function action() {
 
         nextVersion = semver.inc(
             version, 
-            "pre" + level, 
+            "prerelease", 
             branchName
         );
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2306,7 +2306,7 @@ async function getLatestTag(octokit, boolAll = true) {
     console.log("filter only main releases");
     
     const filtered = data.filter((b) => semver.prerelease(b.name) === null);
-    const result = result.pop();
+    const result = filtered.pop();
 
     console.log(`filtered release ${JSON.stringify(result, undefined, 2)}`);
 
@@ -2501,7 +2501,7 @@ async function action() {
         }
 
         // check if commits and issues point to a diffent release
-        const msgLevel = await checkMessages(octokit, latestTag, issLabs);
+        const msgLevel = await checkMessages(octokit, latestMainTag, issLabs);
 
         console.log(`commit messages suggest ${msgLevel} upgrade`)
         

--- a/dist/index.js
+++ b/dist/index.js
@@ -2308,7 +2308,7 @@ async function getLatestTag(octokit, boolAll = true) {
     const filtered = data.filter((b) => semver.prerelease(b.name) === null);
     const result = filtered.pop();
 
-    console.log(`filtered release ${JSON.stringify(result, undefined, 2)}`);
+    // console.log(`filtered release ${JSON.stringify(result, undefined, 2)}`);
 
     return result;
 }
@@ -2352,6 +2352,8 @@ async function checkMessages(octokit, latestTag, issueTags = ["enhancement"]) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
+        console.log(`message is : "${message}"`);
+
         if (wip.test(message)) {
             console.log("    found wip message, skip");
             continue;
@@ -2372,6 +2374,7 @@ async function checkMessages(octokit, latestTag, issueTags = ["enhancement"]) {
         }
 
         if (releaseBump !== "minor" && patch.test(message)) {
+            console.log("    found patch tag");
             releaseBump = "patch";
             continue;
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2352,7 +2352,8 @@ async function checkMessages(octokit, latestTag, issueTags) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
-        console.log(`message is : "${message}"`);
+        console.log(`commit is : "${JSON.stringify(commit, undefined, 2)}"`);
+        // console.log(`message is : "${message}"`);
 
         if (wip.test(message)) {
             console.log("    found wip message, skip");

--- a/dist/index.js
+++ b/dist/index.js
@@ -2320,7 +2320,7 @@ async function loadBranch(octokit, branch) {
         ref: `heads/${branch}`
     });
 
-    // console.log(`branch data: ${ JSON.stringify(result, undefined, 2) } `);
+    console.log(`branch data: ${ JSON.stringify(result, undefined, 2) } `);
 
     return result.data.shift();
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2340,10 +2340,10 @@ async function checkMessages(octokit, latestTag, issueTags) {
         return releaseBump;
     }
 
-    const wip   = new RegExp("#wip");
-    const major = new RegExp("\b#?major\b");
-    const minor = new RegExp("\b#?minor\b");
-    const patch = new RegExp("\b#?patch\b");
+    const wip   = new RegExp("#wip\b");
+    const major = new RegExp("\b#major\b");
+    const minor = new RegExp("\b#minor\b");
+    const patch = new RegExp("\b#patch\b");
 
     const fix   = new RegExp("fix(?:es)? #\d");
     const matcher = new RegExp(/fix(?:es)? #(\d+)\b/);
@@ -2352,7 +2352,7 @@ async function checkMessages(octokit, latestTag, issueTags) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
-        console.log(`commit is : "${JSON.stringify(commit, undefined, 2)}"`);
+        console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
         // console.log(`message is : "${message}"`);
 
         if (wip.test(message)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2325,7 +2325,7 @@ async function loadBranch(octokit, branch) {
     return result.data.shift();
 }
 
-async function checkMessages(octokit, latestTag, issueTags = ["enhancement"]) {
+async function checkMessages(octokit, latestTag, issueTags) {
     const sha = latestTag.commit.sha;
 
     let releaseBump = "none";
@@ -2505,8 +2505,10 @@ async function action() {
 
         // check if commits and issues point to a diffent release
         const msgLevel = await checkMessages(octokit, latestMainTag, issLabs);
+        const msgLevelB = await checkMessages(octokit, latestTag, issLabs);
 
-        console.log(`commit messages suggest ${msgLevel} upgrade`)
+        console.log(`commit messages suggest ${msgLevel} upgrade`);
+        console.log(`commit messages since minor suggest ${msgLevelB} upgrade`);
         
         for (const branch of releaseBranch.split(",").map(b => b.trim())) {
             const testBranchName = new RegExp(branch);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2438,7 +2438,10 @@ async function action() {
     }
     
     // the sha for tagging
-    const sha = branchInfo.object.sha;
+    const sha        = branchInfo.object.sha;
+    const branchName = branchInfo.ref.split("/").pop();
+
+    console.log(`active branch name is ${ branchName }`);
 
     if (customTag) {
         // TODO check if the tag exists, and if not dryRun, then the previous tag should be removed.
@@ -2468,7 +2471,7 @@ async function action() {
         nextVersion = semver.inc(
             version, 
             "pre" + level, 
-            sha.slice(0, 6)
+            branchName
         );
 
         let issLabs = ["enhancement"];
@@ -2483,9 +2486,6 @@ async function action() {
 
         // check if commits and issues point to a diffent release
         const msgLevel = await checkMessages(octokit, latestTag, issLabs);
-
-        // check if the current branch is actually a release branch
-        const branchName = branchInfo.ref.split("/").pop();
         
         for (const branch of releaseBranch.split(",").map(b => b.trim())) {
             const testBranchName = new RegExp(branch);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2289,7 +2289,7 @@ const semver = __webpack_require__(876);
 const owner = github.context.payload.repository.owner.name;
 const repo = github.context.payload.repository.name;
 
-async function getLatestTag(octokit) {
+async function getLatestTag(octokit, boolAll = true) {
     const { data } = await octokit.repos.listTags({
         owner,
         repo
@@ -2298,7 +2298,19 @@ async function getLatestTag(octokit) {
     // ensure the highest version number is the last element
     data.sort((a, b) => semver.compare(semver.clean(a.name), semver.clean(b.name)));
 
-    return data.pop();
+    if (boolAll) {
+        return data.pop();
+    }
+
+    // filter prereleases
+    console.log("filter only main releases");
+    
+    const filtered = data.filter((b) => semver.prerelease(b.name) === null);
+    const result = result.pop();
+
+    console.log(`filtered release ${JSON.stringify(result, undefined, 2)}`);
+
+    return result;
 }
 
 async function loadBranch(octokit, branch) {
@@ -2453,8 +2465,10 @@ async function action() {
         console.log(`maching refs: ${ sha }`);
 
         const latestTag = await getLatestTag(octokit);
+        const latestMainTag = await getLatestTag(octokit, false);
 
         console.log(`the previous tag of the repository ${ JSON.stringify(latestTag, undefined, 2) }`);
+        console.log(`the previous main tag of the repository ${ JSON.stringify(latestMainTag, undefined, 2) }`);
 
         const versionTag = latestTag ? latestTag.name : "0.0.0";
 
@@ -2474,6 +2488,8 @@ async function action() {
             branchName
         );
 
+        console.log(`default to prerelease version ${ nextVersion }`);
+
         let issLabs = ["enhancement"];
 
         if (issueLabels) {
@@ -2486,6 +2502,8 @@ async function action() {
 
         // check if commits and issues point to a diffent release
         const msgLevel = await checkMessages(octokit, latestTag, issLabs);
+
+        console.log(`commit messages suggest ${msgLevel} upgrade`)
         
         for (const branch of releaseBranch.split(",").map(b => b.trim())) {
             const testBranchName = new RegExp(branch);
@@ -2500,6 +2518,7 @@ async function action() {
                     console.log(`commit messages force bump level to ${msgLevel}`);
                     nextVersion = semver.inc(version, msgLevel);
                 }
+
                 break;
             }
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2341,9 +2341,9 @@ async function checkMessages(octokit, latestTag, issueTags) {
     }
 
     const wip   = new RegExp("#wip\b");
-    const major = new RegExp("\b#major\b");
-    const minor = new RegExp("\b#minor\b");
-    const patch = new RegExp("\b#patch\b");
+    const major = new RegExp("#major\b");
+    const minor = new RegExp("#minor\b");
+    const patch = new RegExp("#patch\b");
 
     const fix   = new RegExp("fix(?:es)? #\d");
     const matcher = new RegExp(/fix(?:es)? #(\d+)\b/);
@@ -2356,32 +2356,32 @@ async function checkMessages(octokit, latestTag, issueTags) {
         console.log(`message is : "${message}" on ${commit.commit.committer.date} (${commit.sha})`);
 
         if (wip.test(message)) {
-            console.log("    found wip message, skip");
+            console.log("found wip message, skip");
             continue;
         }
 
         if (major.test(message)) {
-            console.log("    found major tag, stop");
+            console.log("found major tag, stop");
 
             releaseBump = "major";
             break;
         }
         
         if (minor.test(message)) {
-            console.log("    found minor tag");
+            console.log("found minor tag");
 
             releaseBump = "minor";
             continue;
         }
 
         if (releaseBump !== "minor" && patch.test(message)) {
-            console.log("    found patch tag");
+            console.log("found patch tag");
             releaseBump = "patch";
             continue;
         }
 
         if (releaseBump !== "minor" && fix.test(message)) {
-            console.log("    found a fix message, check issue for enhancements");
+            console.log("found a fix message, check issue for enhancements");
             releaseBump = "patch";
 
             const id = matcher.exec(message);
@@ -2389,7 +2389,7 @@ async function checkMessages(octokit, latestTag, issueTags) {
             if (id && Number(id[1]) > 0) {
                 const issue_number = Number(id[1]);
 
-                console.log(`    check issue ${issue_number} for minor labels`);
+                console.log(`check issue ${issue_number} for minor labels`);
 
                 const { data } = await octokit.issues.get({
                     owner,
@@ -2401,17 +2401,20 @@ async function checkMessages(octokit, latestTag, issueTags) {
                     for (const label of data.labels) {
 
                         if (issueTags.indexOf(label.name) >= 0) {
-                            console.log("    found enhancement issue");
+                            console.log("found enhancement issue");
                             releaseBump = "minor";
                             break;
                         }
                     }
                 }
                 else {
-                    console.log("    invalid issue");
+                    console.log("invalid issue");
                 }
             }
+
+            continue;
         }
+        console.log("no info message");
     }
 
     return releaseBump;

--- a/dist/index.js
+++ b/dist/index.js
@@ -2340,12 +2340,12 @@ async function checkMessages(octokit, latestTag, issueTags) {
         return releaseBump;
     }
 
-    const wip   = new RegExp("#wip\b");
-    const major = new RegExp("#major\b");
-    const minor = new RegExp("#minor\b");
-    const patch = new RegExp("#patch\b");
+    const wip   = new RegExp("#wip\\b");
+    const major = new RegExp("#major\\b");
+    const minor = new RegExp("#minor\\b");
+    const patch = new RegExp("#patch\\b");
 
-    const fix   = new RegExp("fix(?:es)? #\d");
+    const fix   = new RegExp("fix(?:es)? #\\d+");
     const matcher = new RegExp(/fix(?:es)? #(\d+)\b/);
 
     for (const commit of result.data) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2325,8 +2325,8 @@ async function loadBranch(octokit, branch) {
     return result.data.shift();
 }
 
-async function checkMessages(octokit, sha, tagSha, issueTags) {
-    // const sha = latestTag.commit.sha;
+async function checkMessages(octokit, branchHeadSha, tagSha, issueTags) {
+    const sha = branchHeadSha;
 
     console.log(`load commits since ${sha}`);
 
@@ -2358,10 +2358,10 @@ async function checkMessages(octokit, sha, tagSha, issueTags) {
             break;
         }
         // console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
-        console.log(`message is : "${message}" on ${commit.commit.committer.date} (${commit.sha})`);
+        // console.log(`message is : "${message}" on ${commit.commit.committer.date} (${commit.sha})`);
 
         if (wip.test(message)) {
-            console.log("found wip message, skip");
+            // console.log("found wip message, skip");
             continue;
         }
 
@@ -2373,14 +2373,14 @@ async function checkMessages(octokit, sha, tagSha, issueTags) {
         }
         
         if (minor.test(message)) {
-            console.log("found minor tag");
+            // console.log("found minor tag");
 
             releaseBump = "minor";
             continue;
         }
 
         if (releaseBump !== "minor" && patch.test(message)) {
-            console.log("found patch tag");
+            // console.log("found patch tag");
             releaseBump = "patch";
             continue;
         }
@@ -2419,10 +2419,21 @@ async function checkMessages(octokit, sha, tagSha, issueTags) {
 
             continue;
         }
-        console.log("no info message");
+        // console.log("no info message");
     }
 
     return releaseBump;
+}
+
+function isReleaseBranch(branchName, branchList) {
+    for (const branch of branchList.split(",").map(b => b.trim())) {
+        const testBranchName = new RegExp(branch);
+
+        if (testBranchName.test(branchName)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 async function action() {
@@ -2513,32 +2524,19 @@ async function action() {
         }
 
         // check if commits and issues point to a diffent release
-        // console.log("================> commits since main");
-        // const msgLevel = await checkMessages(octokit, latestMainTag.commit.sha, issLabs);
-        // console.log("================> commits since alpha");
-        // const msgLevelB = await checkMessages(octokit, latestTag.commit.sha, issLabs);
-        console.log("================> commits in branch");
+        console.log("commits in branch");
         const msgLevel = await checkMessages(octokit, branchInfo.object.sha, latestMainTag.commit.sha,  issLabs);
+        // console.log(`commit messages suggest ${msgLevel} upgrade`);
+    
+        if (isReleaseBranch(branchName, releaseBranch)) {
+            console.log(`${ branchName } is a release branch`);
 
-        console.log(`commit messages suggest ${msgLevel} upgrade`);
-        // console.log(`commit messages since minor suggest ${msgLevelB} upgrade`);
-        // console.log(`commit messages for branch suggest ${msgLevelC} upgrade`);
-        
-        for (const branch of releaseBranch.split(",").map(b => b.trim())) {
-            const testBranchName = new RegExp(branch);
-
-            if (testBranchName.test(branchName)) {
-                console.log(`${ branchName } is a release branch`);
-
-                if (msgLevel === "none") {
-                    nextVersion = semver.inc(version, level);
-                }
-                else {
-                    console.log(`commit messages force bump level to ${msgLevel}`);
-                    nextVersion = semver.inc(version, msgLevel);
-                }
-
-                break;
+            if (msgLevel === "none") {
+                nextVersion = semver.inc(version, level);
+            }
+            else {
+                console.log(`commit messages force bump level to ${msgLevel}`);
+                nextVersion = semver.inc(version, msgLevel);
             }
         }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2352,8 +2352,8 @@ async function checkMessages(octokit, latestTag, issueTags) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
-        console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
-        // console.log(`message is : "${message}"`);
+        // console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
+        console.log(`message is : "${message}" on ${commit.commit.committer.date}`);
 
         if (wip.test(message)) {
             console.log("    found wip message, skip");

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ async function checkMessages(octokit, latestTag, issueTags) {
         const message = commit.commit.message;
 
         // console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
-        console.log(`message is : "${message}" on ${commit.commit.committer.date}` (${commit.sha}));
+        console.log(`message is : "${message}" on ${commit.commit.committer.date} (${commit.sha})`);
 
         if (wip.test(message)) {
             console.log("    found wip message, skip");

--- a/index.js
+++ b/index.js
@@ -2,10 +2,13 @@ const core   = require('@actions/core');
 const github = require('@actions/github');
 const semver = require('semver');
 
-async function getLatestTag(octokit, repository) {
+const owner = github.context.payload.repository.owner.name;
+const repo = github.context.payload.repository.name;
+
+async function getLatestTag(octokit) {
     const { data } = await octokit.repos.listTags({
-        owner: repository.owner.name,
-        repo:  repository.name
+        owner,
+        repo
     });
 
     // ensure the highest version number is the last element
@@ -16,14 +19,102 @@ async function getLatestTag(octokit, repository) {
 
 async function loadBranch(octokit, branch) {
     const result = await octokit.git.listMatchingRefs({
-        owner: github.context.payload.repository.owner.name,
-        repo: github.context.payload.repository.name,
+        owner,
+        repo,
         ref: `heads/${branch}`
     });
 
     // console.log(`branch data: ${ JSON.stringify(result, undefined, 2) } `);
 
     return result.data.shift();
+}
+
+async function checkMessages(octokit, latestTag, issueTags = ["enhancement"]) {
+    const sha = latestTag.commit.sha;
+
+    let releaseBump = "none";
+
+    const result = await octokit.repos.listCommits({
+        owner,
+        repo,
+        sha
+    });
+
+    if (!(result && result.data)) {
+        return releaseBump;
+    }
+
+    const wip   = new RegExp("#wip");
+    const major = new RegExp("\b#?major\b");
+    const minor = new RegExp("\b#?minor\b");
+    const patch = new RegExp("\b#?patch\b");
+
+    const fix   = new RegExp("fix(?:es)? #\d");
+    const matcher = new RegExp(/fix(?:es)? #(\d+)\b/);
+
+    for (const commit of result.data) {
+        // console.log(commit.message);
+        const message = commit.commit.message;
+
+        if (wip.test(message)) {
+            console.log("    found wip message, skip");
+            continue;
+        }
+
+        if (major.test(message)) {
+            console.log("    found major tag, stop");
+
+            releaseBump = "major";
+            break;
+        }
+        
+        if (minor.test(message)) {
+            console.log("    found minor tag");
+
+            releaseBump = "minor";
+            continue;
+        }
+
+        if (releaseBump !== "minor" && patch.test(message)) {
+            releaseBump = "patch";
+            continue;
+        }
+
+        if (releaseBump !== "minor" && fix.test(message)) {
+            console.log("    found a fix message, check issue for enhancements");
+            releaseBump = "patch";
+
+            const id = matcher.exec(message);
+
+            if (id && Number(id[1]) > 0) {
+                const issue_number = Number(id[1]);
+
+                console.log(`    check issue ${issue_number} for minor labels`);
+
+                const { data } = await octokit.issues.get({
+                    owner,
+                    repo,
+                    issue_number    
+                });
+
+                if (data) {
+                    for (const label of data.labels) {
+
+                        if (issueTags.indexOf(label.name) >= 0) {
+                            console.log("    found enhancement issue");
+                            releaseBump = "minor";
+                            break;
+                        }
+                    }
+                }
+                else {
+                    console.log("    invalid issue");
+                }
+            }
+        }
+    }
+
+    return releaseBump;
 }
 
 async function action() {
@@ -38,8 +129,10 @@ async function action() {
     const forceBranch   = core.getInput('branch');
     const releaseBranch = core.getInput('release-branch');
     const withV         = core.getInput('with-v').toLowerCase() === "false" ? "" : "v";
+    const customTag     = core.getInput('tag');
+    const issueLabels   = core.getInput('issue-labels');
 
-    let branchInfo;
+    let branchInfo, nextVersion;
 
     if (forceBranch) {
         console.log(`check forced branch ${forceBranch}`);
@@ -60,60 +153,92 @@ async function action() {
         branchInfo  = await loadBranch(octokit, activeBranch);
     }
     
-    // the tag for tagging
+    // the sha for tagging
     const sha = branchInfo.object.sha;
 
-    console.log(`maching refs: ${ sha }`);
+    if (customTag) {
+        # TODO check if the tag exists, and if not dryRun, then the previous tag should be removed.
 
-    const latestTag = await getLatestTag(octokit, github.context.payload.repository);
-
-    console.log(`the previous tag of the repository ${ JSON.stringify(latestTag, undefined, 2) }`);
-
-    const versionTag = latestTag ? latestTag.name : "0.0.0";
-
-    core.setOutput("tag", versionTag);
-
-    if (latestTag && latestTag.commit.sha === sha) {
-        throw new Error("no new commits, avoid tagging");
+        core.setOutput("new-tag", customTag);
     }
+    else {
 
-    console.log(`The repo tags: ${ JSON.stringify(latestTag, undefined, 2) }`);
+        console.log(`maching refs: ${ sha }`);
 
-    const version   = semver.clean(versionTag);
-    let nextVersion = semver.inc(
-        version, 
-        "pre" + level, 
-        sha.slice(0, 6)
-    );
-    
-    // check if the current branch is actually a release branch
-    const branchName = branchInfo.ref.split("/").pop();
-    
-    for (const branch of releaseBranch.split(",")) {
-        const testBranchName = new RegExp(branch);
-        if (testBranchName.test(branchName)) {
-            console.log(`${ branchName } is a release branch`);
-            nextVersion = semver.inc(version, level);
-            break;
+        const latestTag = await getLatestTag(octokit);
+
+        console.log(`the previous tag of the repository ${ JSON.stringify(latestTag, undefined, 2) }`);
+
+        const versionTag = latestTag ? latestTag.name : "0.0.0";
+
+        core.setOutput("tag", versionTag);
+
+        if (latestTag && latestTag.commit.sha === sha) {
+            throw new Error("no new commits, avoid tagging");
         }
+
+        console.log(`The repo tags: ${ JSON.stringify(latestTag, undefined, 2) }`);
+
+        const version   = semver.clean(versionTag);
+
+        nextVersion = semver.inc(
+            version, 
+            "pre" + level, 
+            sha.slice(0, 6)
+        );
+
+        let issLabs = ["enhancement"];
+
+        if (issueLabels) {
+            const xlabels = issueLabels.split(',').map(lab => lab.trim());
+
+            if (xlabels.length) {
+                issLabs = xlabels;
+            }
+        }
+
+        // check if commits and issues point to a diffent release
+        const msgLevel = await checkMessages(octokit, latestTag, issLabs);
+
+        // check if the current branch is actually a release branch
+        const branchName = branchInfo.ref.split("/").pop();
+        
+        for (const branch of releaseBranch.split(",").map(b => b.trim())) {
+            const testBranchName = new RegExp(branch);
+
+            if (testBranchName.test(branchName)) {
+                console.log(`${ branchName } is a release branch`);
+
+                if (msgLevel === "none") {
+                    nextVersion = semver.inc(version, level);
+                }
+                else {
+                    console.log(`commit messages force bump level to ${msgLevel}`);
+                    nextVersion = semver.inc(version, msgLevel);
+                }
+                break;
+            }
+        }
+
+        console.log( `bump tag ${ nextVersion }` );
+
+        core.setOutput("new-tag", nextVersion);
     }
-
-    console.log( `bump tag ${ nextVersion }` );
-
-    core.setOutput("new-tag", nextVersion);
 
     if (dryRun === "true") {
         console.log("dry run, don't perform tagging");
         return
     }
 
-    console.log(`really add tag ${ withV }${ nextVersion }`);
+    const newTag = `${ withV }${ nextVersion }`;
 
-    const ref = `refs/tags/${ withV }${ nextVersion }`;
+    console.log(`really add tag ${ customTag ? customTag : newTag }`);
+
+    const ref = `refs/tags/${ customTag ? customTag : newTag }`;
 
     const result = await octokit.git.createRef({
-        owner: github.context.payload.repository.owner.name,
-        repo: github.context.payload.repository.name,
+        owner,
+        repo,
         ref,
         sha
     });

--- a/index.js
+++ b/index.js
@@ -57,9 +57,9 @@ async function checkMessages(octokit, latestTag, issueTags) {
     }
 
     const wip   = new RegExp("#wip\b");
-    const major = new RegExp("\b#major\b");
-    const minor = new RegExp("\b#minor\b");
-    const patch = new RegExp("\b#patch\b");
+    const major = new RegExp("#major\b");
+    const minor = new RegExp("#minor\b");
+    const patch = new RegExp("#patch\b");
 
     const fix   = new RegExp("fix(?:es)? #\d");
     const matcher = new RegExp(/fix(?:es)? #(\d+)\b/);
@@ -72,32 +72,32 @@ async function checkMessages(octokit, latestTag, issueTags) {
         console.log(`message is : "${message}" on ${commit.commit.committer.date} (${commit.sha})`);
 
         if (wip.test(message)) {
-            console.log("    found wip message, skip");
+            console.log("found wip message, skip");
             continue;
         }
 
         if (major.test(message)) {
-            console.log("    found major tag, stop");
+            console.log("found major tag, stop");
 
             releaseBump = "major";
             break;
         }
         
         if (minor.test(message)) {
-            console.log("    found minor tag");
+            console.log("found minor tag");
 
             releaseBump = "minor";
             continue;
         }
 
         if (releaseBump !== "minor" && patch.test(message)) {
-            console.log("    found patch tag");
+            console.log("found patch tag");
             releaseBump = "patch";
             continue;
         }
 
         if (releaseBump !== "minor" && fix.test(message)) {
-            console.log("    found a fix message, check issue for enhancements");
+            console.log("found a fix message, check issue for enhancements");
             releaseBump = "patch";
 
             const id = matcher.exec(message);
@@ -105,7 +105,7 @@ async function checkMessages(octokit, latestTag, issueTags) {
             if (id && Number(id[1]) > 0) {
                 const issue_number = Number(id[1]);
 
-                console.log(`    check issue ${issue_number} for minor labels`);
+                console.log(`check issue ${issue_number} for minor labels`);
 
                 const { data } = await octokit.issues.get({
                     owner,
@@ -117,17 +117,20 @@ async function checkMessages(octokit, latestTag, issueTags) {
                     for (const label of data.labels) {
 
                         if (issueTags.indexOf(label.name) >= 0) {
-                            console.log("    found enhancement issue");
+                            console.log("found enhancement issue");
                             releaseBump = "minor";
                             break;
                         }
                     }
                 }
                 else {
-                    console.log("    invalid issue");
+                    console.log("invalid issue");
                 }
             }
+
+            continue;
         }
+        console.log("no info message");
     }
 
     return releaseBump;

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ async function loadBranch(octokit, branch) {
         ref: `heads/${branch}`
     });
 
-    // console.log(`branch data: ${ JSON.stringify(result, undefined, 2) } `);
+    console.log(`branch data: ${ JSON.stringify(result, undefined, 2) } `);
 
     return result.data.shift();
 }

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ async function getLatestTag(octokit, boolAll = true) {
     const filtered = data.filter((b) => semver.prerelease(b.name) === null);
     const result = filtered.pop();
 
-    console.log(`filtered release ${JSON.stringify(result, undefined, 2)}`);
+    // console.log(`filtered release ${JSON.stringify(result, undefined, 2)}`);
 
     return result;
 }
@@ -68,6 +68,8 @@ async function checkMessages(octokit, latestTag, issueTags = ["enhancement"]) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
+        console.log(`message is : "${message}"`);
+
         if (wip.test(message)) {
             console.log("    found wip message, skip");
             continue;
@@ -88,6 +90,7 @@ async function checkMessages(octokit, latestTag, issueTags = ["enhancement"]) {
         }
 
         if (releaseBump !== "minor" && patch.test(message)) {
+            console.log("    found patch tag");
             releaseBump = "patch";
             continue;
         }

--- a/index.js
+++ b/index.js
@@ -226,9 +226,11 @@ async function action() {
         }
 
         // check if commits and issues point to a diffent release
+        console.log("================> commits since main");
         const msgLevel = await checkMessages(octokit, latestMainTag.commit.sha, issLabs);
-        console.log("================> commits in branch");
+        console.log("================> commits since alpha");
         const msgLevelB = await checkMessages(octokit, latestTag.commit.sha, issLabs);
+        console.log("================> commits in branch");
         const msgLevelC = await checkMessages(octokit, branchInfo.object.sha, issLabs);
 
         console.log(`commit messages suggest ${msgLevel} upgrade`);

--- a/index.js
+++ b/index.js
@@ -154,7 +154,10 @@ async function action() {
     }
     
     // the sha for tagging
-    const sha = branchInfo.object.sha;
+    const sha        = branchInfo.object.sha;
+    const branchName = branchInfo.ref.split("/").pop();
+
+    console.log(`active branch name is ${ branchName }`);
 
     if (customTag) {
         // TODO check if the tag exists, and if not dryRun, then the previous tag should be removed.
@@ -184,7 +187,7 @@ async function action() {
         nextVersion = semver.inc(
             version, 
             "pre" + level, 
-            sha.slice(0, 6)
+            branchName
         );
 
         let issLabs = ["enhancement"];
@@ -199,9 +202,6 @@ async function action() {
 
         // check if commits and issues point to a diffent release
         const msgLevel = await checkMessages(octokit, latestTag, issLabs);
-
-        // check if the current branch is actually a release branch
-        const branchName = branchInfo.ref.split("/").pop();
         
         for (const branch of releaseBranch.split(",").map(b => b.trim())) {
             const testBranchName = new RegExp(branch);

--- a/index.js
+++ b/index.js
@@ -68,8 +68,8 @@ async function checkMessages(octokit, latestTag, issueTags) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
-        console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
-        // console.log(`message is : "${message}"`);
+        // console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
+        console.log(`message is : "${message}" on ${commit.commit.committer.date}`);
 
         if (wip.test(message)) {
             console.log("    found wip message, skip");

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ async function loadBranch(octokit, branch) {
     return result.data.shift();
 }
 
-async function checkMessages(octokit, latestTag, issueTags = ["enhancement"]) {
+async function checkMessages(octokit, latestTag, issueTags) {
     const sha = latestTag.commit.sha;
 
     let releaseBump = "none";
@@ -221,8 +221,10 @@ async function action() {
 
         // check if commits and issues point to a diffent release
         const msgLevel = await checkMessages(octokit, latestMainTag, issLabs);
+        const msgLevelB = await checkMessages(octokit, latestTag, issLabs);
 
-        console.log(`commit messages suggest ${msgLevel} upgrade`)
+        console.log(`commit messages suggest ${msgLevel} upgrade`);
+        console.log(`commit messages since minor suggest ${msgLevelB} upgrade`);
         
         for (const branch of releaseBranch.split(",").map(b => b.trim())) {
             const testBranchName = new RegExp(branch);

--- a/index.js
+++ b/index.js
@@ -68,7 +68,8 @@ async function checkMessages(octokit, latestTag, issueTags) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
-        console.log(`message is : "${message}"`);
+        console.log(`commit is : "${JSON.stringify(commit, undefined, 2)}"`);
+        // console.log(`message is : "${message}"`);
 
         if (wip.test(message)) {
             console.log("    found wip message, skip");

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ async function loadBranch(octokit, branch) {
     return result.data.shift();
 }
 
-async function checkMessages(octokit, sha, issueTags) {
+async function checkMessages(octokit, sha, tagSha, issueTags) {
     // const sha = latestTag.commit.sha;
 
     console.log(`load commits since ${sha}`);
@@ -70,6 +70,9 @@ async function checkMessages(octokit, sha, issueTags) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
+        if (commit.sha === tagSha) {
+            break;
+        }
         // console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
         console.log(`message is : "${message}" on ${commit.commit.committer.date} (${commit.sha})`);
 
@@ -226,16 +229,16 @@ async function action() {
         }
 
         // check if commits and issues point to a diffent release
-        console.log("================> commits since main");
-        const msgLevel = await checkMessages(octokit, latestMainTag.commit.sha, issLabs);
-        console.log("================> commits since alpha");
-        const msgLevelB = await checkMessages(octokit, latestTag.commit.sha, issLabs);
+        // console.log("================> commits since main");
+        // const msgLevel = await checkMessages(octokit, latestMainTag.commit.sha, issLabs);
+        // console.log("================> commits since alpha");
+        // const msgLevelB = await checkMessages(octokit, latestTag.commit.sha, issLabs);
         console.log("================> commits in branch");
-        const msgLevelC = await checkMessages(octokit, branchInfo.object.sha, issLabs);
+        const msgLevel = await checkMessages(octokit, branchInfo.object.sha, latestMainTag.commit.sha,  issLabs);
 
         console.log(`commit messages suggest ${msgLevel} upgrade`);
-        console.log(`commit messages since minor suggest ${msgLevelB} upgrade`);
-        console.log(`commit messages for branch suggest ${msgLevelC} upgrade`);
+        // console.log(`commit messages since minor suggest ${msgLevelB} upgrade`);
+        // console.log(`commit messages for branch suggest ${msgLevelC} upgrade`);
         
         for (const branch of releaseBranch.split(",").map(b => b.trim())) {
             const testBranchName = new RegExp(branch);

--- a/index.js
+++ b/index.js
@@ -41,8 +41,10 @@ async function loadBranch(octokit, branch) {
     return result.data.shift();
 }
 
-async function checkMessages(octokit, latestTag, issueTags) {
-    const sha = latestTag.commit.sha;
+async function checkMessages(octokit, sha, issueTags) {
+    // const sha = latestTag.commit.sha;
+
+    console.log(`load commits since ${sha}`);
 
     let releaseBump = "none";
 
@@ -224,11 +226,14 @@ async function action() {
         }
 
         // check if commits and issues point to a diffent release
-        const msgLevel = await checkMessages(octokit, latestMainTag, issLabs);
-        const msgLevelB = await checkMessages(octokit, latestTag, issLabs);
+        const msgLevel = await checkMessages(octokit, latestMainTag.commit.sha, issLabs);
+        console.log("================> commits in branch");
+        const msgLevelB = await checkMessages(octokit, latestTag.commit.sha, issLabs);
+        const msgLevelC = await checkMessages(octokit, branchInfo.object.sha, issLabs);
 
         console.log(`commit messages suggest ${msgLevel} upgrade`);
         console.log(`commit messages since minor suggest ${msgLevelB} upgrade`);
+        console.log(`commit messages for branch suggest ${msgLevelC} upgrade`);
         
         for (const branch of releaseBranch.split(",").map(b => b.trim())) {
             const testBranchName = new RegExp(branch);

--- a/index.js
+++ b/index.js
@@ -56,10 +56,10 @@ async function checkMessages(octokit, latestTag, issueTags) {
         return releaseBump;
     }
 
-    const wip   = new RegExp("#wip");
-    const major = new RegExp("\b#?major\b");
-    const minor = new RegExp("\b#?minor\b");
-    const patch = new RegExp("\b#?patch\b");
+    const wip   = new RegExp("#wip\b");
+    const major = new RegExp("\b#major\b");
+    const minor = new RegExp("\b#minor\b");
+    const patch = new RegExp("\b#patch\b");
 
     const fix   = new RegExp("fix(?:es)? #\d");
     const matcher = new RegExp(/fix(?:es)? #(\d+)\b/);
@@ -68,7 +68,7 @@ async function checkMessages(octokit, latestTag, issueTags) {
         // console.log(commit.message);
         const message = commit.commit.message;
 
-        console.log(`commit is : "${JSON.stringify(commit, undefined, 2)}"`);
+        console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
         // console.log(`message is : "${message}"`);
 
         if (wip.test(message)) {

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ async function action() {
     const sha = branchInfo.object.sha;
 
     if (customTag) {
-        # TODO check if the tag exists, and if not dryRun, then the previous tag should be removed.
+        // TODO check if the tag exists, and if not dryRun, then the previous tag should be removed.
 
         core.setOutput("new-tag", customTag);
     }

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ async function action() {
 
         nextVersion = semver.inc(
             version, 
-            "pre" + level, 
+            "prerelease", 
             branchName
         );
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ async function getLatestTag(octokit, boolAll = true) {
     console.log("filter only main releases");
     
     const filtered = data.filter((b) => semver.prerelease(b.name) === null);
-    const result = result.pop();
+    const result = filtered.pop();
 
     console.log(`filtered release ${JSON.stringify(result, undefined, 2)}`);
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ async function checkMessages(octokit, latestTag, issueTags) {
         const message = commit.commit.message;
 
         // console.log(`commit is : "${JSON.stringify(commit.commit, undefined, 2)}"`);
-        console.log(`message is : "${message}" on ${commit.commit.committer.date}`);
+        console.log(`message is : "${message}" on ${commit.commit.committer.date}` (${commit.sha}));
 
         if (wip.test(message)) {
             console.log("    found wip message, skip");

--- a/index.js
+++ b/index.js
@@ -56,12 +56,12 @@ async function checkMessages(octokit, latestTag, issueTags) {
         return releaseBump;
     }
 
-    const wip   = new RegExp("#wip\b");
-    const major = new RegExp("#major\b");
-    const minor = new RegExp("#minor\b");
-    const patch = new RegExp("#patch\b");
+    const wip   = new RegExp("#wip\\b");
+    const major = new RegExp("#major\\b");
+    const minor = new RegExp("#minor\\b");
+    const patch = new RegExp("#patch\\b");
 
-    const fix   = new RegExp("fix(?:es)? #\d");
+    const fix   = new RegExp("fix(?:es)? #\\d+");
     const matcher = new RegExp(/fix(?:es)? #(\d+)\b/);
 
     for (const commit of result.data) {


### PR DESCRIPTION
This turned into a #minor upgrade 

- allows for custom tags (without semver bumping)
- checks messages since last tag for bump levels
- for fixed issues, check issue labels for bump levels
- proper prerelease support